### PR TITLE
Fixed the call of mat64

### DIFF
--- a/liblinear.go
+++ b/liblinear.go
@@ -120,7 +120,7 @@ func Train(X, y *mat64.Dense, bias float64, pm *Parameter) *Model {
 
 	nRows, nCols := X.Dims()
 
-	cY := mapCDouble(y.Col(nil, 0))
+	cY := mapCDouble(y.ColView(0).RawVector().Data)
 	cX := toFeatureNodes(X)
 	problem.x = &cX[0]
 	problem.y = &cY[0]
@@ -164,8 +164,8 @@ func PredictProba(model *Model, X *mat64.Dense) *mat64.Dense {
 }
 
 func Accuracy(y_true, y_pred *mat64.Dense) float64 {
-	y1 := y_true.Col(nil, 0)
-	y2 := y_pred.Col(nil, 0)
+	y1 := y_true.ColView(0).RawVector().Data
+	y2 := y_pred.ColView(0).RawVector().Data
 
 	total := 0.0
 	correct := 0.0

--- a/liblinear_test.go
+++ b/liblinear_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Liblinear", func() {
 		It("should return probability estimation", func() {
 			X, y := ReadLibsvm("test_fixture/heart_scale", true)
 			model := Train(X, y, -1, gParam)
-			y_pred := PredictProba(model, X).Row(nil, 0)
+			y_pred := PredictProba(model, X).RowView(0).RawVector().Data
 			Expect(y_pred[0]).To(BeNumerically("~", 0.95409, 1e-5))
 			Expect(y_pred[1]).To(BeNumerically("~", 0.0459103, 1e-5))
 		})


### PR DESCRIPTION
Because `Col()` and `Row()` is not available in the latest  `mat64` in [matrix](https://github.com/gonum/matrix), the build fails now.
This PR fixes it.
